### PR TITLE
Typo

### DIFF
--- a/src/components/toolbox/FloatingBox.tsx
+++ b/src/components/toolbox/FloatingBox.tsx
@@ -18,7 +18,7 @@ const styles = {
     root: {
       position: "fixed" as const,
       right: "0px",
-      top: "20%",
+      top: "35%",
     },
     hr: {
       backgroundColor: commonStyle.main_color.color,

--- a/src/components/widget/feedback/feedback.tsx
+++ b/src/components/widget/feedback/feedback.tsx
@@ -1,4 +1,3 @@
-import { Typography } from "@material-ui/core";
 import React from "react";
 import GitHubButton from "react-github-btn";
 
@@ -41,7 +40,12 @@ export const FeedBack = () => {
       </label>
       <div>Help us BUIDL zero2ckb, together!</div>
       <br />
-      <p style={{ color: "antiquewhite" }}>contact: retric@cryptape.com</p>
+      <p style={{ color: "antiquewhite" }}>
+        Join{" "}
+        <a target="_blank" href="https://discord.gg/4PfPBzRZcp">
+          The Zero2ckb DAO
+        </a>{" "}
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
 + lock_arg: indicates the first 20 bits of the wallet's corresponding public key hash. Think of it simply as a fingerprint of the public key.

   Should be 20 bytes

+ This is the distinction between the type script and the lock script. The former protects the ownership of the box and the latter secures the data transformation rules. 

    exchange former and latter. The former  secures the data transformation rules and the latter protects the ownership of the box 

+  in the second summary, The size of the entire cell cannot exceed the value of the capacity field
   
	This term is duplicated, it was shown twice in the list. 